### PR TITLE
Fix 404 errors on page refresh by adding SPA redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -13,3 +13,8 @@
   from = "/api/*"
   status = 200
   to = "/.netlify/functions/api/:splat"
+
+[[redirects]]
+  from = "/*"
+  to = "/index.html"
+  status = 200


### PR DESCRIPTION
## Purpose

The user was experiencing 404 errors when refreshing pages on their single-page application (SPA). While the site worked correctly on initial load and navigation, refreshing any page other than the home page resulted in a "Page not found" error from Netlify. This is a common issue with SPAs where the server needs to serve the main index.html file for all routes to allow client-side routing to handle the navigation.

## Code changes

Added a catch-all redirect rule to `netlify.toml` that redirects all requests (`/*`) to `/index.html` with a 200 status code. This ensures that when users refresh pages or access URLs directly, Netlify serves the main application file instead of returning a 404 error, allowing the client-side router to handle the routing properly.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1d7643387ac941f2bdab5f2ce101e351/flare-lab)

👀 [Preview Link](https://1d7643387ac941f2bdab5f2ce101e351-flare-lab.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1d7643387ac941f2bdab5f2ce101e351</projectId>-->
<!--<branchName>flare-lab</branchName>-->